### PR TITLE
Dev increase benchmark stability

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -11,6 +11,7 @@ criterion = "0.5"
 rand = "0.9"
 rand_xoshiro = "0.7"
 rand_chacha = "0.9"
+jemallocator = "0.5"
 
 [[bench]]
 name = "single-prize"

--- a/benches/benches/multiple-prize.rs
+++ b/benches/benches/multiple-prize.rs
@@ -49,33 +49,34 @@ const FACTOR: usize = 3;
 const TIME_MEASUREMENT_BASE: Duration = Duration::from_secs(10);
 const WARM_UP_COEFF: u32 = 5;
 
+// `large` would be k * n * log2(n), where k is `FACTOR`
+// `medium` would be k * n
+// `small` would be k * log2(n)
 const fn large() -> usize {
     FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize
 }
-
 const fn medium() -> usize {
     FACTOR * NUM_ENTRANTS
 }
-
 const fn small() -> usize {
     FACTOR * NUM_ENTRANTS.ilog2() as usize
 }
 
+// least time needed for measuring 100 samples
 fn measure(time_coeff: u32) -> Duration {
     time_coeff * TIME_MEASUREMENT_BASE
 }
 
+// the warmup would take at least 20 cycles
+// for at least 100 samples, the coeff is 100/20 = 5
 fn warm(time_coeff: u32) -> Duration {
     time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF
 }
 
 pub fn bench(c: &mut Criterion) {
     // bench function naming rule
-    // [number of tickets_t]_[number of prizes_p]_[Rng]
-    // `large` would be ku log2(u), where k is `FACTOR`
-    // `medium` would be u
-    // `small` would be log2(u)
-    // Rng would be either SmallRng (default) or StdRng
+    // multiple_[number of tickets_t]_[number of prizes_p]_[Rng]
+    // Rng would be either Prng (default) or CsPrng
     {
         let mut g = c.benchmark_group("multiple_large_t_large_p");
         let nr_ticket = large();
@@ -222,7 +223,7 @@ pub fn bench(c: &mut Criterion) {
         });
     }
     {
-        let mut g = c.benchmark_group("multiple_medium_t_medium_p_std_rng");
+        let mut g = c.benchmark_group("multiple_medium_t_medium_p_csprng");
         let nr_ticket = medium();
         let nr_prize = medium();
         let time_coeff = 1;

--- a/benches/benches/multiple-prize.rs
+++ b/benches/benches/multiple-prize.rs
@@ -50,9 +50,13 @@ pub fn bench(c: &mut Criterion) {
     // Rng would be either SmallRng (default) or StdRng
     const NUM_ENTRANTS: usize = 65536;
     const FACTOR: usize = 3;
+    const TIME_MEASUREMENT_BASE: Duration = Duration::from_secs(10);
+    const WARM_UP_COEFF: u32 = 10;
     {
         let mut g = c.benchmark_group("multiple_large_t_large_p");
-        g.measurement_time(Duration::from_secs(180));
+        let time_coeff = 18;
+        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
+            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         let nr_ticket = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
         let nr_prize = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
         g.bench_function("array", |b| {
@@ -81,7 +85,9 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("multiple_large_t_medium_p");
         let nr_ticket = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
         let nr_prize = NUM_ENTRANTS;
-        g.measurement_time(Duration::from_secs(90));
+        let time_coeff = 9;
+        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
+            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_multiple!(array
@@ -108,7 +114,9 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("multiple_large_t_small_p");
         let nr_ticket = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
         let nr_prize = NUM_ENTRANTS.ilog2() as usize;
-        g.measurement_time(Duration::from_secs(30));
+        let time_coeff = 3;
+        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
+            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_multiple!(array
@@ -135,7 +143,9 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("multiple_medium_t_large_p");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
-        g.measurement_time(Duration::from_secs(90));
+        let time_coeff = 6;
+        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
+            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_multiple!(array
@@ -162,7 +172,9 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("multiple_medium_t_medium_p");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = NUM_ENTRANTS;
-        g.measurement_time(Duration::from_secs(30));
+        let time_coeff = 3;
+        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
+            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_multiple!(array
@@ -189,7 +201,9 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("multiple_medium_t_medium_p_std_rng");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = NUM_ENTRANTS;
-        g.measurement_time(Duration::from_secs(30));
+        let time_coeff = 3;
+        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
+            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         g.bench_function("array", |b| {
             let mut rng = CsPrng::seed_from_u64(1);
             bench_iter_multiple!(array
@@ -216,7 +230,9 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("multiple_medium_t_small_p");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = NUM_ENTRANTS.ilog2() as usize;
-        g.measurement_time(Duration::from_secs(30));
+        let time_coeff = 3;
+        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
+            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_multiple!(array
@@ -230,33 +246,6 @@ pub fn bench(c: &mut Criterion) {
 
         g.bench_function("tree", |b| {
             let mut rng = Prng::seed_from_u64(1);
-            bench_iter_multiple!(tree
-                b,
-                rng,
-                nr_prize,
-                1.max(nr_prize / NUM_ENTRANTS),
-                1.max(nr_ticket / NUM_ENTRANTS)
-            );
-        });
-    }
-    {
-        let mut g = c.benchmark_group("multiple_medium_t_small_p_std_rng");
-        let nr_ticket = NUM_ENTRANTS;
-        let nr_prize = NUM_ENTRANTS.ilog2() as usize;
-        g.measurement_time(Duration::from_secs(30));
-        g.bench_function("array", |b| {
-            let mut rng = CsPrng::seed_from_u64(1);
-            bench_iter_multiple!(array
-                b,
-                rng,
-                nr_prize,
-                1.max(nr_prize / NUM_ENTRANTS),
-                1.max(nr_ticket / NUM_ENTRANTS)
-            );
-        });
-
-        g.bench_function("tree", |b| {
-            let mut rng = CsPrng::seed_from_u64(1);
             bench_iter_multiple!(tree
                 b,
                 rng,

--- a/benches/benches/multiple-prize.rs
+++ b/benches/benches/multiple-prize.rs
@@ -6,6 +6,9 @@ use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng as CsPrng;
 use rand_xoshiro::Xoshiro256PlusPlus as Prng;
 
+#[global_allocator]
+static ALLOCATOR: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 criterion_group!(
     name = benches;
     config = Criterion::default();

--- a/benches/benches/multiple-prize.rs
+++ b/benches/benches/multiple-prize.rs
@@ -52,7 +52,7 @@ pub fn bench(c: &mut Criterion) {
     const FACTOR: usize = 3;
     {
         let mut g = c.benchmark_group("multiple_large_t_large_p");
-        g.measurement_time(Duration::from_secs(30)).sample_size(50);
+        g.measurement_time(Duration::from_secs(180));
         let nr_ticket = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
         let nr_prize = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
         g.bench_function("array", |b| {
@@ -81,7 +81,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("multiple_large_t_medium_p");
         let nr_ticket = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
         let nr_prize = NUM_ENTRANTS;
-        g.measurement_time(Duration::from_secs(10));
+        g.measurement_time(Duration::from_secs(90));
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_multiple!(array
@@ -108,7 +108,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("multiple_large_t_small_p");
         let nr_ticket = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
         let nr_prize = NUM_ENTRANTS.ilog2() as usize;
-        g.measurement_time(Duration::from_secs(10));
+        g.measurement_time(Duration::from_secs(30));
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_multiple!(array
@@ -135,6 +135,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("multiple_medium_t_large_p");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
+        g.measurement_time(Duration::from_secs(90));
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_multiple!(array
@@ -161,6 +162,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("multiple_medium_t_medium_p");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = NUM_ENTRANTS;
+        g.measurement_time(Duration::from_secs(30));
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_multiple!(array
@@ -187,6 +189,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("multiple_medium_t_medium_p_std_rng");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = NUM_ENTRANTS;
+        g.measurement_time(Duration::from_secs(30));
         g.bench_function("array", |b| {
             let mut rng = CsPrng::seed_from_u64(1);
             bench_iter_multiple!(array
@@ -213,6 +216,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("multiple_medium_t_small_p");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = NUM_ENTRANTS.ilog2() as usize;
+        g.measurement_time(Duration::from_secs(30));
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_multiple!(array
@@ -239,6 +243,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("multiple_medium_t_small_p_std_rng");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = NUM_ENTRANTS.ilog2() as usize;
+        g.measurement_time(Duration::from_secs(30));
         g.bench_function("array", |b| {
             let mut rng = CsPrng::seed_from_u64(1);
             bench_iter_multiple!(array

--- a/benches/benches/multiple-prize.rs
+++ b/benches/benches/multiple-prize.rs
@@ -11,7 +11,7 @@ static ALLOCATOR: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 criterion_group!(
     name = benches;
-    config = Criterion::default();
+    config = Criterion::default().noise_threshold(0.03);
     targets = bench
 );
 criterion_main!(benches);
@@ -54,10 +54,10 @@ pub fn bench(c: &mut Criterion) {
     const NUM_ENTRANTS: usize = 65536;
     const FACTOR: usize = 3;
     const TIME_MEASUREMENT_BASE: Duration = Duration::from_secs(10);
-    const WARM_UP_COEFF: u32 = 10;
+    const WARM_UP_COEFF: u32 = 5;
     {
         let mut g = c.benchmark_group("multiple_large_t_large_p");
-        let time_coeff = 18;
+        let time_coeff = 9;
         g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
             .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         let nr_ticket = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
@@ -88,7 +88,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("multiple_large_t_medium_p");
         let nr_ticket = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
         let nr_prize = NUM_ENTRANTS;
-        let time_coeff = 9;
+        let time_coeff = 2;
         g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
             .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         g.bench_function("array", |b| {
@@ -117,7 +117,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("multiple_large_t_small_p");
         let nr_ticket = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
         let nr_prize = NUM_ENTRANTS.ilog2() as usize;
-        let time_coeff = 3;
+        let time_coeff = 1;
         g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
             .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         g.bench_function("array", |b| {
@@ -146,7 +146,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("multiple_medium_t_large_p");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
-        let time_coeff = 6;
+        let time_coeff = 4;
         g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
             .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         g.bench_function("array", |b| {
@@ -175,7 +175,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("multiple_medium_t_medium_p");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = NUM_ENTRANTS;
-        let time_coeff = 3;
+        let time_coeff = 1;
         g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
             .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         g.bench_function("array", |b| {
@@ -204,7 +204,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("multiple_medium_t_medium_p_std_rng");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = NUM_ENTRANTS;
-        let time_coeff = 3;
+        let time_coeff = 1;
         g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
             .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         g.bench_function("array", |b| {
@@ -233,7 +233,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("multiple_medium_t_small_p");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = NUM_ENTRANTS.ilog2() as usize;
-        let time_coeff = 3;
+        let time_coeff = 1;
         g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
             .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         g.bench_function("array", |b| {

--- a/benches/benches/multiple-prize.rs
+++ b/benches/benches/multiple-prize.rs
@@ -44,6 +44,31 @@ macro_rules! bench_iter_multiple {
     };
 }
 
+const NUM_ENTRANTS: usize = 65536;
+const FACTOR: usize = 3;
+const TIME_MEASUREMENT_BASE: Duration = Duration::from_secs(10);
+const WARM_UP_COEFF: u32 = 5;
+
+const fn large() -> usize {
+    FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize
+}
+
+const fn medium() -> usize {
+    FACTOR * NUM_ENTRANTS
+}
+
+const fn small() -> usize {
+    FACTOR * NUM_ENTRANTS.ilog2() as usize
+}
+
+fn measure(time_coeff: u32) -> Duration {
+    time_coeff * TIME_MEASUREMENT_BASE
+}
+
+fn warm(time_coeff: u32) -> Duration {
+    time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF
+}
+
 pub fn bench(c: &mut Criterion) {
     // bench function naming rule
     // [number of tickets_t]_[number of prizes_p]_[Rng]
@@ -51,17 +76,13 @@ pub fn bench(c: &mut Criterion) {
     // `medium` would be u
     // `small` would be log2(u)
     // Rng would be either SmallRng (default) or StdRng
-    const NUM_ENTRANTS: usize = 65536;
-    const FACTOR: usize = 3;
-    const TIME_MEASUREMENT_BASE: Duration = Duration::from_secs(10);
-    const WARM_UP_COEFF: u32 = 5;
     {
         let mut g = c.benchmark_group("multiple_large_t_large_p");
+        let nr_ticket = large();
+        let nr_prize = large();
         let time_coeff = 9;
-        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
-            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
-        let nr_ticket = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
-        let nr_prize = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
+        g.measurement_time(measure(time_coeff))
+            .warm_up_time(warm(time_coeff));
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_multiple!(array
@@ -86,11 +107,11 @@ pub fn bench(c: &mut Criterion) {
     }
     {
         let mut g = c.benchmark_group("multiple_large_t_medium_p");
-        let nr_ticket = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
-        let nr_prize = NUM_ENTRANTS;
+        let nr_ticket = large();
+        let nr_prize = medium();
         let time_coeff = 2;
-        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
-            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
+        g.measurement_time(measure(time_coeff))
+            .warm_up_time(warm(time_coeff));
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_multiple!(array
@@ -115,11 +136,11 @@ pub fn bench(c: &mut Criterion) {
     }
     {
         let mut g = c.benchmark_group("multiple_large_t_small_p");
-        let nr_ticket = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
-        let nr_prize = NUM_ENTRANTS.ilog2() as usize;
+        let nr_ticket = large();
+        let nr_prize = small();
         let time_coeff = 1;
-        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
-            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
+        g.measurement_time(measure(time_coeff))
+            .warm_up_time(warm(time_coeff));
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_multiple!(array
@@ -144,11 +165,11 @@ pub fn bench(c: &mut Criterion) {
     }
     {
         let mut g = c.benchmark_group("multiple_medium_t_large_p");
-        let nr_ticket = NUM_ENTRANTS;
-        let nr_prize = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
+        let nr_ticket = medium();
+        let nr_prize = large();
         let time_coeff = 4;
-        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
-            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
+        g.measurement_time(measure(time_coeff))
+            .warm_up_time(warm(time_coeff));
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_multiple!(array
@@ -173,11 +194,11 @@ pub fn bench(c: &mut Criterion) {
     }
     {
         let mut g = c.benchmark_group("multiple_medium_t_medium_p");
-        let nr_ticket = NUM_ENTRANTS;
-        let nr_prize = NUM_ENTRANTS;
+        let nr_ticket = medium();
+        let nr_prize = medium();
         let time_coeff = 1;
-        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
-            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
+        g.measurement_time(measure(time_coeff))
+            .warm_up_time(warm(time_coeff));
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_multiple!(array
@@ -202,11 +223,11 @@ pub fn bench(c: &mut Criterion) {
     }
     {
         let mut g = c.benchmark_group("multiple_medium_t_medium_p_std_rng");
-        let nr_ticket = NUM_ENTRANTS;
-        let nr_prize = NUM_ENTRANTS;
+        let nr_ticket = medium();
+        let nr_prize = medium();
         let time_coeff = 1;
-        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
-            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
+        g.measurement_time(measure(time_coeff))
+            .warm_up_time(warm(time_coeff));
         g.bench_function("array", |b| {
             let mut rng = CsPrng::seed_from_u64(1);
             bench_iter_multiple!(array
@@ -231,11 +252,11 @@ pub fn bench(c: &mut Criterion) {
     }
     {
         let mut g = c.benchmark_group("multiple_medium_t_small_p");
-        let nr_ticket = NUM_ENTRANTS;
-        let nr_prize = NUM_ENTRANTS.ilog2() as usize;
+        let nr_ticket = medium();
+        let nr_prize = small();
         let time_coeff = 1;
-        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
-            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
+        g.measurement_time(measure(time_coeff))
+            .warm_up_time(warm(time_coeff));
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_multiple!(array

--- a/benches/benches/single-prize.rs
+++ b/benches/benches/single-prize.rs
@@ -11,7 +11,7 @@ static ALLOCATOR: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 criterion_group!(
     name = benches;
-    config = Criterion::default();
+    config = Criterion::default().noise_threshold(0.03);
     targets = bench
 );
 criterion_main!(benches);
@@ -55,10 +55,10 @@ pub fn bench(c: &mut Criterion) {
     const NUM_ENTRANTS: usize = 65536;
     const FACTOR: usize = 3;
     const TIME_MEASUREMENT_BASE: Duration = Duration::from_secs(10);
-    const WARM_UP_COEFF: u32 = 10;
+    const WARM_UP_COEFF: u32 = 3;
     {
         let mut g = c.benchmark_group("single_large_t_large_p");
-        let time_coeff = 18;
+        let time_coeff = 9;
         g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
             .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         let nr_ticket = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
@@ -89,7 +89,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("single_large_t_medium_p");
         let nr_ticket = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
         let nr_prize = NUM_ENTRANTS;
-        let time_coeff = 9;
+        let time_coeff = 2;
         g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
             .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         g.bench_function("array", |b| {
@@ -118,7 +118,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("single_large_t_small_p");
         let nr_ticket = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
         let nr_prize = NUM_ENTRANTS.ilog2() as usize;
-        let time_coeff = 3;
+        let time_coeff = 1;
         g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
             .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         g.bench_function("array", |b| {
@@ -147,7 +147,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("single_medium_t_large_p");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
-        let time_coeff = 6;
+        let time_coeff = 4;
         g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
             .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         g.bench_function("array", |b| {
@@ -176,7 +176,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("single_medium_t_medium_p");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = NUM_ENTRANTS;
-        let time_coeff = 3;
+        let time_coeff = 1;
         g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
             .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         g.bench_function("array", |b| {
@@ -205,7 +205,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("single_medium_t_medium_p_std_rng");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = NUM_ENTRANTS;
-        let time_coeff = 3;
+        let time_coeff = 1;
         g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
             .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         g.bench_function("array", |b| {
@@ -234,7 +234,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("single_medium_t_small_p");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = NUM_ENTRANTS.ilog2() as usize;
-        let time_coeff = 3;
+        let time_coeff = 1;
         g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
             .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         g.bench_function("array", |b| {

--- a/benches/benches/single-prize.rs
+++ b/benches/benches/single-prize.rs
@@ -6,6 +6,9 @@ use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng as CsPrng;
 use rand_xoshiro::Xoshiro256PlusPlus as Prng;
 
+#[global_allocator]
+static ALLOCATOR: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 criterion_group!(
     name = benches;
     config = Criterion::default();

--- a/benches/benches/single-prize.rs
+++ b/benches/benches/single-prize.rs
@@ -51,9 +51,13 @@ pub fn bench(c: &mut Criterion) {
     // Rng would be either SmallRng (default) or StdRng
     const NUM_ENTRANTS: usize = 65536;
     const FACTOR: usize = 3;
+    const TIME_MEASUREMENT_BASE: Duration = Duration::from_secs(10);
+    const WARM_UP_COEFF: u32 = 10;
     {
         let mut g = c.benchmark_group("single_large_t_large_p");
-        g.measurement_time(Duration::from_secs(180));
+        let time_coeff = 18;
+        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
+            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         let nr_ticket = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
         let nr_prize = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
         g.bench_function("array", |b| {
@@ -82,7 +86,9 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("single_large_t_medium_p");
         let nr_ticket = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
         let nr_prize = NUM_ENTRANTS;
-        g.measurement_time(Duration::from_secs(90));
+        let time_coeff = 9;
+        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
+            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_single!(array
@@ -109,7 +115,9 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("single_large_t_small_p");
         let nr_ticket = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
         let nr_prize = NUM_ENTRANTS.ilog2() as usize;
-        g.measurement_time(Duration::from_secs(30));
+        let time_coeff = 3;
+        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
+            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_single!(array
@@ -136,7 +144,9 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("single_medium_t_large_p");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
-        g.measurement_time(Duration::from_secs(90));
+        let time_coeff = 6;
+        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
+            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_single!(array
@@ -163,7 +173,9 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("single_medium_t_medium_p");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = NUM_ENTRANTS;
-        g.measurement_time(Duration::from_secs(30));
+        let time_coeff = 3;
+        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
+            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_single!(array
@@ -190,7 +202,9 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("single_medium_t_medium_p_std_rng");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = NUM_ENTRANTS;
-        g.measurement_time(Duration::from_secs(30));
+        let time_coeff = 3;
+        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
+            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         g.bench_function("array", |b| {
             let mut rng = CsPrng::seed_from_u64(1);
             bench_iter_single!(array
@@ -217,7 +231,9 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("single_medium_t_small_p");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = NUM_ENTRANTS.ilog2() as usize;
-        g.measurement_time(Duration::from_secs(30));
+        let time_coeff = 3;
+        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
+            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_single!(array
@@ -231,33 +247,6 @@ pub fn bench(c: &mut Criterion) {
 
         g.bench_function("tree", |b| {
             let mut rng = Prng::seed_from_u64(1);
-            bench_iter_single!(tree
-                b,
-                rng,
-                nr_prize,
-                1.max(nr_prize / NUM_ENTRANTS),
-                1.max(nr_ticket / NUM_ENTRANTS)
-            );
-        });
-    }
-    {
-        let mut g = c.benchmark_group("single_medium_t_small_p_std_rng");
-        let nr_ticket = NUM_ENTRANTS;
-        let nr_prize = NUM_ENTRANTS.ilog2() as usize;
-        g.measurement_time(Duration::from_secs(30));
-        g.bench_function("array", |b| {
-            let mut rng = CsPrng::seed_from_u64(1);
-            bench_iter_single!(array
-                b,
-                rng,
-                nr_prize,
-                1.max(nr_prize / NUM_ENTRANTS),
-                1.max(nr_ticket / NUM_ENTRANTS)
-            );
-        });
-
-        g.bench_function("tree", |b| {
-            let mut rng = CsPrng::seed_from_u64(1);
             bench_iter_single!(tree
                 b,
                 rng,

--- a/benches/benches/single-prize.rs
+++ b/benches/benches/single-prize.rs
@@ -53,7 +53,7 @@ pub fn bench(c: &mut Criterion) {
     const FACTOR: usize = 3;
     {
         let mut g = c.benchmark_group("single_large_t_large_p");
-        g.measurement_time(Duration::from_secs(30)).sample_size(50);
+        g.measurement_time(Duration::from_secs(180));
         let nr_ticket = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
         let nr_prize = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
         g.bench_function("array", |b| {
@@ -82,7 +82,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("single_large_t_medium_p");
         let nr_ticket = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
         let nr_prize = NUM_ENTRANTS;
-        g.measurement_time(Duration::from_secs(10));
+        g.measurement_time(Duration::from_secs(90));
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_single!(array
@@ -109,7 +109,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("single_large_t_small_p");
         let nr_ticket = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
         let nr_prize = NUM_ENTRANTS.ilog2() as usize;
-        g.measurement_time(Duration::from_secs(10));
+        g.measurement_time(Duration::from_secs(30));
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_single!(array
@@ -136,6 +136,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("single_medium_t_large_p");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
+        g.measurement_time(Duration::from_secs(90));
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_single!(array
@@ -162,6 +163,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("single_medium_t_medium_p");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = NUM_ENTRANTS;
+        g.measurement_time(Duration::from_secs(30));
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_single!(array
@@ -188,6 +190,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("single_medium_t_medium_p_std_rng");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = NUM_ENTRANTS;
+        g.measurement_time(Duration::from_secs(30));
         g.bench_function("array", |b| {
             let mut rng = CsPrng::seed_from_u64(1);
             bench_iter_single!(array
@@ -214,6 +217,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("single_medium_t_small_p");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = NUM_ENTRANTS.ilog2() as usize;
+        g.measurement_time(Duration::from_secs(30));
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_single!(array
@@ -240,6 +244,7 @@ pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("single_medium_t_small_p_std_rng");
         let nr_ticket = NUM_ENTRANTS;
         let nr_prize = NUM_ENTRANTS.ilog2() as usize;
+        g.measurement_time(Duration::from_secs(30));
         g.bench_function("array", |b| {
             let mut rng = CsPrng::seed_from_u64(1);
             bench_iter_single!(array

--- a/benches/benches/single-prize.rs
+++ b/benches/benches/single-prize.rs
@@ -49,33 +49,34 @@ const FACTOR: usize = 3;
 const TIME_MEASUREMENT_BASE: Duration = Duration::from_secs(10);
 const WARM_UP_COEFF: u32 = 5;
 
+// `large` would be k * n * log2(n), where k is `FACTOR`
+// `medium` would be k * n
+// `small` would be k * log2(n)
 const fn large() -> usize {
     FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize
 }
-
 const fn medium() -> usize {
     FACTOR * NUM_ENTRANTS
 }
-
 const fn small() -> usize {
     FACTOR * NUM_ENTRANTS.ilog2() as usize
 }
 
+// least time needed for measuring 100 samples
 fn measure(time_coeff: u32) -> Duration {
     time_coeff * TIME_MEASUREMENT_BASE
 }
 
+// the warmup would take at least 20 cycles
+// for at least 100 samples, the coeff is 100/20 = 5
 fn warm(time_coeff: u32) -> Duration {
     time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF
 }
 
 pub fn bench(c: &mut Criterion) {
     // bench function naming rule
-    // [number of tickets_t]_[number of prizes_p]_[Rng]
-    // `large` would be ku log2(u), where k is `FACTOR`
-    // `medium` would be u
-    // `small` would be log2(u)
-    // Rng would be either SmallRng (default) or StdRng
+    // single_[number of tickets_t]_[number of prizes_p]_[Rng]
+    // Rng would be either Prng (default) or CsPrng
     {
         let mut g = c.benchmark_group("single_large_t_large_p");
         let nr_ticket = large();
@@ -222,7 +223,7 @@ pub fn bench(c: &mut Criterion) {
         });
     }
     {
-        let mut g = c.benchmark_group("single_medium_t_medium_p_std_rng");
+        let mut g = c.benchmark_group("single_medium_t_medium_p_csprng");
         let nr_ticket = medium();
         let nr_prize = medium();
         let time_coeff = 1;

--- a/benches/benches/single-prize.rs
+++ b/benches/benches/single-prize.rs
@@ -44,6 +44,30 @@ macro_rules! bench_iter_single {
     };
 }
 
+const NUM_ENTRANTS: usize = 65536;
+const FACTOR: usize = 3;
+const TIME_MEASUREMENT_BASE: Duration = Duration::from_secs(10);
+const WARM_UP_COEFF: u32 = 5;
+
+const fn large() -> usize {
+    FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize
+}
+
+const fn medium() -> usize {
+    FACTOR * NUM_ENTRANTS
+}
+
+const fn small() -> usize {
+    FACTOR * NUM_ENTRANTS.ilog2() as usize
+}
+
+fn measure(time_coeff: u32) -> Duration {
+    time_coeff * TIME_MEASUREMENT_BASE
+}
+
+fn warm(time_coeff: u32) -> Duration {
+    time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF
+}
 
 pub fn bench(c: &mut Criterion) {
     // bench function naming rule
@@ -52,17 +76,13 @@ pub fn bench(c: &mut Criterion) {
     // `medium` would be u
     // `small` would be log2(u)
     // Rng would be either SmallRng (default) or StdRng
-    const NUM_ENTRANTS: usize = 65536;
-    const FACTOR: usize = 3;
-    const TIME_MEASUREMENT_BASE: Duration = Duration::from_secs(10);
-    const WARM_UP_COEFF: u32 = 3;
     {
         let mut g = c.benchmark_group("single_large_t_large_p");
+        let nr_ticket = large();
+        let nr_prize = large();
         let time_coeff = 9;
-        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
-            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
-        let nr_ticket = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
-        let nr_prize = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
+        g.measurement_time(measure(time_coeff))
+            .warm_up_time(warm(time_coeff));
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_single!(array
@@ -87,11 +107,11 @@ pub fn bench(c: &mut Criterion) {
     }
     {
         let mut g = c.benchmark_group("single_large_t_medium_p");
-        let nr_ticket = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
-        let nr_prize = NUM_ENTRANTS;
+        let nr_ticket = large();
+        let nr_prize = medium();
         let time_coeff = 2;
-        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
-            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
+        g.measurement_time(measure(time_coeff))
+            .warm_up_time(warm(time_coeff));
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_single!(array
@@ -116,11 +136,11 @@ pub fn bench(c: &mut Criterion) {
     }
     {
         let mut g = c.benchmark_group("single_large_t_small_p");
-        let nr_ticket = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
-        let nr_prize = NUM_ENTRANTS.ilog2() as usize;
+        let nr_ticket = large();
+        let nr_prize = small();
         let time_coeff = 1;
-        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
-            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
+        g.measurement_time(measure(time_coeff))
+            .warm_up_time(warm(time_coeff));
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_single!(array
@@ -145,11 +165,11 @@ pub fn bench(c: &mut Criterion) {
     }
     {
         let mut g = c.benchmark_group("single_medium_t_large_p");
-        let nr_ticket = NUM_ENTRANTS;
-        let nr_prize = FACTOR * NUM_ENTRANTS * NUM_ENTRANTS.ilog2() as usize;
+        let nr_ticket = medium();
+        let nr_prize = large();
         let time_coeff = 4;
-        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
-            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
+        g.measurement_time(measure(time_coeff))
+            .warm_up_time(warm(time_coeff));
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_single!(array
@@ -174,11 +194,11 @@ pub fn bench(c: &mut Criterion) {
     }
     {
         let mut g = c.benchmark_group("single_medium_t_medium_p");
-        let nr_ticket = NUM_ENTRANTS;
-        let nr_prize = NUM_ENTRANTS;
+        let nr_ticket = medium();
+        let nr_prize = medium();
         let time_coeff = 1;
-        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
-            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
+        g.measurement_time(measure(time_coeff))
+            .warm_up_time(warm(time_coeff));
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_single!(array
@@ -203,11 +223,11 @@ pub fn bench(c: &mut Criterion) {
     }
     {
         let mut g = c.benchmark_group("single_medium_t_medium_p_std_rng");
-        let nr_ticket = NUM_ENTRANTS;
-        let nr_prize = NUM_ENTRANTS;
+        let nr_ticket = medium();
+        let nr_prize = medium();
         let time_coeff = 1;
-        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
-            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
+        g.measurement_time(measure(time_coeff))
+            .warm_up_time(warm(time_coeff));
         g.bench_function("array", |b| {
             let mut rng = CsPrng::seed_from_u64(1);
             bench_iter_single!(array
@@ -232,11 +252,11 @@ pub fn bench(c: &mut Criterion) {
     }
     {
         let mut g = c.benchmark_group("single_medium_t_small_p");
-        let nr_ticket = NUM_ENTRANTS;
-        let nr_prize = NUM_ENTRANTS.ilog2() as usize;
+        let nr_ticket = medium();
+        let nr_prize = small();
         let time_coeff = 1;
-        g.measurement_time(time_coeff * TIME_MEASUREMENT_BASE)
-            .warm_up_time(time_coeff * TIME_MEASUREMENT_BASE / WARM_UP_COEFF);
+        g.measurement_time(measure(time_coeff))
+            .warm_up_time(warm(time_coeff));
         g.bench_function("array", |b| {
             let mut rng = Prng::seed_from_u64(1);
             bench_iter_single!(array


### PR DESCRIPTION
The rerun of a benchmark would still give a large deviation from the previous run. Therefore, it is necessary to reduce the instability, or increase the tolerance to make every run would fall in statistically p > 0.5 range. 